### PR TITLE
fix(deps): Implement better management of ditto dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+opendssdirect.py
+pandas
+networkx
+traitlets
+ditto @ git+https://github.com/NREL/ditto@master

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,13 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from setuptools import setup, find_packages
-from setuptools.command.develop import develop
-import os
 
-# command = 'git clone -b timeseries_updates https://github.com/NREL/ditto.git'
-command = 'git clone -b master https://github.com/NREL/ditto.git'
-os.system(command)
 
 with open("LICENSE.md") as f:
     license = f.read()
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 setup(
     name="UrbanoptDittoReader",
@@ -42,10 +40,5 @@ setup(
     license=license,
     packages=find_packages(exclude=("tests", "docs")),
     python_requires='>=3.7',
-    install_requires=[
-        'opendssdirect.py',
-        'pandas',
-        'networkx',
-        'traitlets'
-    ]
+    install_requires=requirements
 )


### PR DESCRIPTION
This commit shows how I would recommend handling the ditto dependency from github.

When implemented this way, ditto is just like all of the other dependencies and, when there's eventually a new stable release of ditto to PyPI, we can just swap out the whole github link with the word 'ditto' and everything will work just as before.