### PR TITLE
Opendss time fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The start_date and
     start_time. It runs the entire year if timestamp not found.
 1. "end_date": Optional, String, Indicates the end date of the simulation. Uses format "YYYY/MM/DD"
 1. "end_time": Optional, String, Indicates the end time of the simulation. Uses format "HH:MM:SS".
-   The end_date and end_time are aggregate to get the timestamp using format (using format
+   The end_date and end_time are concatenated to get the timestamp (using format
    "YYYY/MM/DD HH:MM:SS") for the config file and is cross referenced with the timestamps in the
    SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
    SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ The start_date and
    file that is cross referenced with the timestamps in the
    SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
    SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
-   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestep not found.
+   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It assumes start_time to be 00:00:00 if start_date is found but no
+    start_time. It runs the entire year if timestamp not found.
 1. "end_date": Optional, String, Indicates the end date of the simulation. Uses format "YYYY/MM/DD"
 1. "end_time": Optional, String, Indicates the end time of the simulation. Uses format "HH:MM:SS".
    The end_date and end_time are aggregate to get the timestamp using format (using format
    "YYYY/MM/DD HH:MM:SS") for the config file and is cross referenced with the timestamps in the
    SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
    SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
-   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestep not found.
+   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestamp not found.
 1. "timestep": Optional, Float number of minutes between each simulation. If smaller than timesteps (or not an even multiple) provided by the reopt feature reports (if use_repot is true), or urbanopt feature reports (if use_reopt is false), an error is raised
 1. "upgrade_transformers": Optional, Boolean (True/False). If true, will automatically upgrade transformers that are sized smaller than the sum of the peak loads that it serves. Does not update geojson file - just opendss output files
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The start_date and
    "YYYY/MM/DD HH:MM:SS") for the config file and is cross referenced with the timestamps in the
    SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
    SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
-   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestamp not found.
+   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It assumes end_time to be 23:00:00 if end_date is found but no end_time. It runs the entire year if timestamp not found.
 1. "timestep": Optional, Float number of minutes between each simulation. If smaller than timesteps (or not an even multiple) provided by the reopt feature reports (if use_repot is true), or urbanopt feature reports (if use_reopt is false), an error is raised
 1. "upgrade_transformers": Optional, Boolean (True/False). If true, will automatically upgrade transformers that are sized smaller than the sum of the peak loads that it serves. Does not update geojson file - just opendss output files
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You are expected to have an existing URBANopt project dir with successful simula
 1. "start_time": Optional, String, Indicates the start time of the simulation. Uses format
    "HH:MM:SS". 
 The start_date and
-   start_time are aggregate to get the timestamp (using format "YYYY/MM/DD HH:MM:SS") for the config
+   start_time are concatenated to get the timestamp (using format "YYYY/MM/DD HH:MM:SS") for the config
    file that is cross referenced with the timestamps in the
    SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
    SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and

--- a/README.md
+++ b/README.md
@@ -32,8 +32,22 @@ You are expected to have an existing URBANopt project dir with successful simula
 1. "equipment_file": Optional, Path to custom equipment file
 1. "opendss_folder": Required, Path to dir created by this command, holding openDSS output
 1. "use_reopt": Required, Boolean (True/False) to analyze reopt data, if it has been provided
-1. "start_time": Optional, String timestamp of the start time of the simulation. Uses format "YYYY/MM/DD HH:MM:SS". Cross referenced with the timestamps in the SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if the time is not found.
-1. "end_time": Optional, String timestamp of the end time of the simulation. Uses format "YYYY/MM/DD HH:MM:SS". Cross referenced with the timestamps in the SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if the time is not found.
+1. "start_date": Optional, String, Indicates the start date of the simulation. Uses format "YYYY/MM/DD"
+1. "start_time": Optional, String, Indicates the start time of the simulation. Uses format
+   "HH:MM:SS". 
+The start_date and
+   start_time are aggregate to get the timestamp (using format "YYYY/MM/DD HH:MM:SS") for the config
+   file that is cross referenced with the timestamps in the
+   SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
+   SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
+   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestep not found.
+1. "end_date": Optional, String, Indicates the end date of the simulation. Uses format "YYYY/MM/DD"
+1. "end_time": Optional, String, Indicates the end time of the simulation. Uses format "HH:MM:SS".
+   The end_date and end_time are aggregate to get the timestamp using format (using format
+   "YYYY/MM/DD HH:MM:SS") for the config file and is cross referenced with the timestamps in the
+   SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
+   SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
+   SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestep not found.
 1. "timestep": Optional, Float number of minutes between each simulation. If smaller than timesteps (or not an even multiple) provided by the reopt feature reports (if use_repot is true), or urbanopt feature reports (if use_reopt is false), an error is raised
 1. "upgrade_transformers": Optional, Boolean (True/False). If true, will automatically upgrade transformers that are sized smaller than the sum of the peak loads that it serves. Does not update geojson file - just opendss output files
 

--- a/urbanopt_ditto_reader/ditto_reader_cli.py
+++ b/urbanopt_ditto_reader/ditto_reader_cli.py
@@ -62,7 +62,7 @@ def cli():
     "--start_date",
     type=str,
     default=None,
-    help="Beginning date of simulation. If invalid or None, all timepoints will be run"
+    help="Beginning date of simulation. Uses format 'YYYY/MM/DD'. If invalid or None, all timepoints will be run"
 )
 @click.option(
     "-b",

--- a/urbanopt_ditto_reader/ditto_reader_cli.py
+++ b/urbanopt_ditto_reader/ditto_reader_cli.py
@@ -69,7 +69,7 @@ def cli():
     "--start_time",
     type=str,
     default=None,
-    help="Beginning timestamp of simulation. If invalid or None, all timepoints will be run"
+    help="Beginning timestamp of simulation. Uses format 'HH:MM:SS' If invalid or None, all timepoints will be run"
 )
 @click.option(
     "-n",
@@ -83,7 +83,7 @@ def cli():
     "--end_time",
     type=str,
     default=None,
-    help="Ending timestamp of simulation. If invalid or None, all timepoints will be run"
+    help="Ending timestamp of simulation. Uses format 'HH/MM/SS'. If invalid or None, all timepoints will be run"
 )
 @click.option(
     "-t",

--- a/urbanopt_ditto_reader/ditto_reader_cli.py
+++ b/urbanopt_ditto_reader/ditto_reader_cli.py
@@ -58,6 +58,13 @@ def cli():
     help="Path to optional custom equipment file"
 )
 @click.option(
+    "-a",
+    "--start_date",
+    type=str,
+    default=None,
+    help="Beginning date of simulation. If invalid or None, all timepoints will be run"
+)
+@click.option(
     "-b",
     "--start_time",
     type=str,
@@ -66,6 +73,13 @@ def cli():
 )
 @click.option(
     "-n",
+    "--end_date",
+    type=str,
+    default=None,
+    help="Ending date of simulation. If invalid or None, all timepoints will be run"
+)
+@click.option(
+    "-d",
     "--end_time",
     type=str,
     default=None,
@@ -98,7 +112,7 @@ def cli():
     help="Flag to automatically upgrade transformers if undersized"
 )
 
-def run_opendss(scenario_file, feature_file, equipment, start_time, end_time, timestep, reopt, config, upgrade):
+def run_opendss(scenario_file, feature_file, equipment, start_date, start_time, end_date, end_time, timestep, reopt, config, upgrade):
     """
     \b
     Run OpenDSS on an existing URBANopt scenario.
@@ -108,8 +122,20 @@ def run_opendss(scenario_file, feature_file, equipment, start_time, end_time, ti
     :param scenario_file: Path, location and name of scenario csv file
     :param feature_file: Path, location & name of feature json file
     :param equipment: Path, location and name of custom equipment file
-    :param start_time: String, timestamp of the start time of the simulation. Uses format "YYYY/MM/DD HH:MM:SS". Cross referenced with the timestamps in the SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestep not found.
-    :param end_time: String, timestamp of the end time of the simulation. Uses format "YYYY/MM/DD HH:MM:SS". Cross referenced with the timestamps in the SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It runs the entire year if timestep not found.
+    :param start_date: String, date of the start of simulation. Uses format "YYYY/MM/DD"
+    :param start_time: String, start time of the simulation. Uses format "HH:MM:SS". The start_date
+    and start_time are aggregate to get the timestamp (using format "YYYY/MM/DD HH:MM:SS") for the config file and is cross referenced with the timestamps in the SCENARIO_NAME/opendss/profiles/timestamps.csv
+    file created from profiles in SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv
+    if use_reopt is true and SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if
+    use_reopt is false. It runs the entire year if timestep not found.
+    :param end_date: String, date of the end of simulation. Uses format "YYYY/MM/DD"
+    :param end_time: String, end time of the simulation. Uses format "HH:MM:SS". The end_date
+    and end_time are aggregate to get the timestamp using format (using format "YYYY/MM/DD
+    HH:MM:SS") for the config file and is cross referenced with the timestamps in the
+    SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
+    SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
+    SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It
+    runs the entire year if timestep not found.
     :param timestep: Float, number of minutes between each simulation. If larger than timesteps provided by the reopt feature reports (if use_repot is true), or urbanopt feature reports (if use_reopt is false), an error is raised
     :param reopt: Boolean, flag to specify that reopt data is present and OpenDSS analysis should include it
     :param upgrade: Boolean, flag to automatically ugrade transformers that are smaller than the sum of the peak loads that they serve.
@@ -124,13 +150,15 @@ def run_opendss(scenario_file, feature_file, equipment, start_time, end_time, ti
             scenario_name = Path(scenario_file).stem
             scenario_dir = Path(scenario_file).parent / "run" / scenario_name
 
+            start_date_time = start_date + " " + start_time
+            end_date_time = end_date + " " + end_time
             config_dict = {
                 'urbanopt_scenario_file': scenario_file,
                 'urbanopt_geojson_file': feature_file,
                 'use_reopt': reopt,
                 'opendss_folder': scenario_dir / 'opendss',
-                'start_time': start_time,
-                'end_time': end_time,
+                'start_time': start_date_time,
+                'end_time': end_date_time,
                 'timestep': timestep,
                 'upgrade_transformers': upgrade
                 }

--- a/urbanopt_ditto_reader/ditto_reader_cli.py
+++ b/urbanopt_ditto_reader/ditto_reader_cli.py
@@ -127,15 +127,17 @@ def run_opendss(scenario_file, feature_file, equipment, start_date, start_time, 
     and start_time are aggregate to get the timestamp (using format "YYYY/MM/DD HH:MM:SS") for the config file and is cross referenced with the timestamps in the SCENARIO_NAME/opendss/profiles/timestamps.csv
     file created from profiles in SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv
     if use_reopt is true and SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if
-    use_reopt is false. It runs the entire year if timestep not found.
+    use_reopt is false. It assumes start_time to be 00:00:00 if start_date is found but no
+    start_time. It runs the entire year if timestamp is not found.
     :param end_date: String, date of the end of simulation. Uses format "YYYY/MM/DD"
     :param end_time: String, end time of the simulation. Uses format "HH:MM:SS". The end_date
     and end_time are aggregate to get the timestamp using format (using format "YYYY/MM/DD
     HH:MM:SS") for the config file and is cross referenced with the timestamps in the
     SCENARIO_NAME/opendss/profiles/timestamps.csv file created from profiles in
     SCENARIO_NAME/FEATURE_ID/feature_reports/feature_report_reopt.csv if use_reopt is true and
-    SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false. It
-    runs the entire year if timestep not found.
+    SCENARIO_NAME/FEATURE_ID/feature_reports/default_feature_report.csv if use_reopt is false.  It assumes end_time to be 23:00:00 if end_date is found but no
+    end_time. It
+    runs the entire year if timestamp is not found.
     :param timestep: Float, number of minutes between each simulation. If larger than timesteps provided by the reopt feature reports (if use_repot is true), or urbanopt feature reports (if use_reopt is false), an error is raised
     :param reopt: Boolean, flag to specify that reopt data is present and OpenDSS analysis should include it
     :param upgrade: Boolean, flag to automatically ugrade transformers that are smaller than the sum of the peak loads that they serve.
@@ -150,8 +152,21 @@ def run_opendss(scenario_file, feature_file, equipment, start_date, start_time, 
             scenario_name = Path(scenario_file).stem
             scenario_dir = Path(scenario_file).parent / "run" / scenario_name
 
-            start_date_time = start_date + " " + start_time
-            end_date_time = end_date + " " + end_time
+            if start_date and start_time:
+                start_date_time = start_date + " " + start_time
+            elif start_date and start_time is None:
+                start_date_time = start_date + " 00:00:00"
+            elif start_date is None or start_time is None:
+                start_date_time = None
+
+            if end_date and end_time:
+                end_date_time = end_date + " " + end_time
+            elif end_date and end_time is None:
+                end_date_time = end_date + " 23:00:00"
+            elif end_date is None or end_time is None:
+                end_date_time = None
+
+
             config_dict = {
                 'urbanopt_scenario_file': scenario_file,
                 'urbanopt_geojson_file': feature_file,

--- a/urbanopt_ditto_reader/ditto_reader_cli.py
+++ b/urbanopt_ditto_reader/ditto_reader_cli.py
@@ -76,7 +76,7 @@ def cli():
     "--end_date",
     type=str,
     default=None,
-    help="Ending date of simulation. If invalid or None, all timepoints will be run"
+    help="Ending date of simulation. Uses format 'YYYY/MM/DD'. If invalid or None, all timepoints will be run"
 )
 @click.option(
     "-d",


### PR DESCRIPTION
Separates out the start/end date and time arguments coming from the URBANopt cli. These are combined before passing into the config file.