### PR TITLE
Cleaner dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       # - id: check-hooks-apply # Fails if a hook doesn't apply to any file
   # Run the Ruff linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.1.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -34,6 +34,6 @@ repos:
   # Run the Ruff formatter
   # https://docs.astral.sh/ruff/integrations/#pre-commit
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.1.6
     hooks:
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,18 +24,16 @@ repos:
     # hooks:
       # - id: check-useless-excludes # Ensure the exclude syntax is correct
       # - id: check-hooks-apply # Fails if a hook doesn't apply to any file
+  # Run the Ruff linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.1.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
         types_or: [python, pyi, jupyter]
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
+  # Run the Ruff formatter
+  # https://docs.astral.sh/ruff/integrations/#pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
     hooks:
-    - id: black-jupyter
-default_language_version:
-  python: python3.10
-# Don't check dirs/files that are brought in from other repositories
-# exclude: resources/samplers/|resources/options_lookup.tsv
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
         "Programming Language :: Python :: 3.12"
     ]
 dependencies = [
-    "ditto.py[opendss] @ git+https://github.com/vtnate/ditto.git@master",
+    "ditto.py[opendss] ~= 0.2.4",
     "opendssdirect.py ~= 0.8",
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,6 @@ readme = {file = ["README.md", ]}
 minversion = "6.0"
 testpaths = "tests"
 
-[tool.black]
-line-length = 120 # Ruff and Black must have the same line-length setting to work together
-
 # https://github.com/charliermarsh/ruff
 [tool.ruff]
 fix = true # automatically fix problems if possible
@@ -72,6 +69,10 @@ select = ["RUF", "E", "F", "I", "UP", "N", "S", "BLE", "A", "C4", "T10", "ISC", 
 "Q", "SIM", "TID", "ARG", "DTZ", "PD", "PGH", "PLC", "PLE", "PLR", "PLW", "PIE", "COM"] # Enable these rules
 ignore = ["PLR0913", "PLR2004", "PLR0402", "COM812", "COM819", "SIM108", "ARG002"] # except for these specific errors
 line-length = 120
+
+# https://docs.astral.sh/ruff/settings/#format
+[tool.ruff.format]
+# quote-style = "double"
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101", "S607", "S603"] # assert statements are allowed in tests, and paths are safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,14 @@ classifiers = [
 dependencies = [
     "ditto.py[opendss]~=0.2",
     "opendssdirect.py ~= 0.8",
+    "traitlets >5, <5.10",
     ]
 
 [project.optional-dependencies]
 dev = [
     "pytest ~= 7.4",
     "pre-commit ~= 3.3",
-    "black ~= 23.7",
-    "ruff ~= 0.1.1",
+    "ruff ~= 0.1.6",
 ]
 
 # https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
         "Programming Language :: Python :: 3.12"
     ]
 dependencies = [
-    "ditto.py[opendss] @ git+https://github.com/NREL/ditto.git@master",
+    "ditto.py[opendss] @ git+https://github.com/vtnate/ditto.git@master",
     "opendssdirect.py ~= 0.8",
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ testpaths = "tests"
 fix = true # automatically fix problems if possible
 select = ["RUF", "E", "F", "I", "UP", "N", "S", "BLE", "A", "C4", "T10", "ISC", "ICN", "PT",
 "Q", "SIM", "TID", "ARG", "DTZ", "PD", "PGH", "PLC", "PLE", "PLR", "PLW", "PIE", "COM"] # Enable these rules
-ignore = ["PLR0913", "PLR2004", "PLR0402", "COM812", "COM819", "SIM108", "ARG002"] # except for these specific errors
+ignore = ["PLR0913", "PLR2004", "PLR0402", "COM812", "COM819", "SIM108", "ARG002", "ISC001"] # except for these specific errors
 line-length = 120
 
 # https://docs.astral.sh/ruff/settings/#format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,8 @@ classifiers = [
         "Programming Language :: Python :: 3.12"
     ]
 dependencies = [
-    "ditto.py[opendss]~=0.2",
+    "ditto.py[opendss] @ git+https://github.com/NREL/ditto.git@master",
     "opendssdirect.py ~= 0.8",
-    "traitlets >5, <5.10",
     ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,15 +35,14 @@ classifiers = [
 dependencies = [
     "ditto.py[opendss]~=0.2",
     "opendssdirect.py ~= 0.8",
-    "traitlets >5, <5.10",
     ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest >= 6.0",
+    "pytest ~= 7.4",
     "pre-commit ~= 3.3",
     "black ~= 23.7",
-    "ruff ~= 0.1",
+    "ruff ~= 0.1.1",
 ]
 
 # https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

--- a/urbanopt_ditto_reader/reader/read.py
+++ b/urbanopt_ditto_reader/reader/read.py
@@ -413,8 +413,9 @@ class Reader(AbstractReader):
                 # under properties. This is normally an optional field.
                 if "phases" not in element["properties"]:
                     raise ValueError(
-                        "Transformer {} does not have phases included in geojson "
-                        "file".format(element["properties"]["id"])
+                        "Transformer {} does not have phases included in geojson " "file".format(
+                            element["properties"]["id"]
+                        )
                     )
                 phases = element["properties"]["phases"]
                 if len(phases) != int(trans_props["Nphases"]):


### PR DESCRIPTION
- Use Ruff formatter instead of Black
- Remove direct traitlets dependency because it has been resolved in ditto.py
- Use newest version of ditto.py
- Be a little more selective with versioning requirements
- Run Ruff formatter