### PR TITLE
Explicitly classify readme.md as markdown in pyproject.toml for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
 
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 [tool.setuptools.dynamic]
-readme = {file = ["README.md", ]}
+readme = {file = "README.md", content-type = "text/markdown"}
 
 [project.urls]
 "Homepage" = "https://github.com/urbanopt/urbanopt-ditto-reader"


### PR DESCRIPTION
SetupTools needs to be told that `readme.md` file is markdown, otherwise it defaults to [declaring readme's as rst](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata). This makes PyPI parse the file incorrectly and it will refuse a release push. Infinite sadness.

I suffered a lot with this in https://github.com/NREL/ThermalNetwork/pull/10 before coming to this solution.