### PR TITLE
Changelog configs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - DO NOT MERGE
+      - invalid
+      - dependencies
+      - tests
+    authors:
+      - octocat
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+        - Feature
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -40,7 +40,7 @@ jobs:
     - build
     runs-on: ubuntu-latest
     environment:
-      name: release
+      name: pypi_release
       url: https://pypi.org/p/urbanopt-ditto-reader
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Date Range 12/15/2022 - 12/05/2023
 ### Future changes will be published using Github automated formatting at the release itself. Those changes are copied here.
 - Upgrade opendssdirect to ~0.8
+- Upgrade ditto.py to ~0..2.4
 - Use modern TOML packaging format
 - Add tests & CI
 - Set up pre-commit with linting and formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # URBANopt DiTTo Reader CHANGELOG
 
+# Version 0.6.0
+Date Range 12/15/2022 - 12/05/2023
+### Future changes will be published using Github automated formatting at the release itself. Those changes are copied here.
+- Upgrade opendssdirect to ~0.8
+- Use modern TOML packaging format
+- Add tests & CI
+- Set up pre-commit with linting and formatting
+- Set up automated release to PyPI on GitHub release
+
 # Version 0.5.1
 Date Range 11/28/2022 - 12/15/2022
 - Update dependency management for DiTTo


### PR DESCRIPTION
- New Github config to categorize and use PRs to automatically write the changelog
    - We use this in the GMT
- Update changelog.md with the changes in v0.6.0, and note that future changelog will be generated automatically in the GitHub releases.