### PR TITLE
set default config to not use reopt

### DIFF
--- a/urbanopt_ditto_reader/example_config.json
+++ b/urbanopt_ditto_reader/example_config.json
@@ -3,7 +3,7 @@
     "equipment_file": "urbanopt_ditto_reader/extended_catalog.json",
     "opendss_folder": "example/run/baseline_scenario/opendss",
     "urbanopt_geojson_file": "example/urbanopt_example.json",
-    "use_reopt": true,
+    "use_reopt": false,
     "start_time": "2019/01/15 01:00:00",
     "end_time": "2019/01/16 01:00:00",
     "timestep": 120


### PR DESCRIPTION
This config file is used by the CLI and it was making ditto-reader try to read a file that only exists if you've done reopt post-processing. Since it was defaulting to true, we could hit this when not trying to do reopt analysis, and an error was raised [here](https://github.com/urbanopt/urbanopt-ditto-reader/blob/develop/urbanopt_ditto_reader/reader/read.py#L516-L518).